### PR TITLE
fix sight only deliver first result

### DIFF
--- a/src/agentsight/src/parser/http/request.rs
+++ b/src/agentsight/src/parser/http/request.rs
@@ -57,6 +57,14 @@ impl ParsedRequest {
     }
 
     /// Decode HTTP chunked transfer encoding and parse as JSON
+    ///
+    /// All slicing uses `str::get(..)` so that arbitrary binary bodies (e.g.
+    /// OpenTelemetry Protobuf streams that we converted via
+    /// `from_utf8_lossy`) can't panic with "byte index N is not a char
+    /// boundary" when the parsed chunk size happens to point into the middle
+    /// of a multi-byte `U+FFFD` replacement char. In those cases we simply
+    /// abandon the chunked-decode attempt and return `None`, which the caller
+    /// treats as "not JSON".
     fn decode_chunked_json(body: &str) -> Option<serde_json::Value> {
         let mut decoded = String::new();
         let mut remaining = body;
@@ -64,7 +72,7 @@ impl ParsedRequest {
         loop {
             // Find the chunk size line
             let newline_pos = remaining.find("\r\n")?;
-            let size_str = &remaining[..newline_pos];
+            let size_str = remaining.get(..newline_pos)?;
             let chunk_size = usize::from_str_radix(size_str.trim(), 16).ok()?;
 
             if chunk_size == 0 {
@@ -72,18 +80,19 @@ impl ParsedRequest {
             }
 
             let data_start = newline_pos + 2;
-            let data_end = data_start + chunk_size;
+            let data_end = data_start.checked_add(chunk_size)?;
             if data_end > remaining.len() {
-                // Partial chunk — decode what we have
-                decoded.push_str(&remaining[data_start..]);
+                // Partial chunk — decode what we have (still guarded against
+                // landing inside a multi-byte char from from_utf8_lossy).
+                decoded.push_str(remaining.get(data_start..)?);
                 break;
             }
-            decoded.push_str(&remaining[data_start..data_end]);
+            decoded.push_str(remaining.get(data_start..data_end)?);
 
             // Skip past chunk data and trailing \r\n
-            remaining = &remaining[data_end..];
+            remaining = remaining.get(data_end..)?;
             if remaining.starts_with("\r\n") {
-                remaining = &remaining[2..];
+                remaining = remaining.get(2..)?;
             }
         }
 
@@ -287,6 +296,26 @@ mod tests {
     #[test]
     fn test_decode_chunked_json_invalid() {
         assert!(ParsedRequest::decode_chunked_json("not chunked").is_none());
+    }
+
+    /// Regression: a binary body (e.g. OTLP/Protobuf) passed through
+    /// `String::from_utf8_lossy` contains `U+FFFD` replacement chars that are
+    /// 3 bytes wide. If the chunk-size parser succeeds by accident and the
+    /// computed slice boundary lands inside one of those chars, the old
+    /// implementation panicked with "byte index N is not a char boundary".
+    /// The current implementation must return `None` instead.
+    #[test]
+    fn test_decode_chunked_json_binary_body_does_not_panic() {
+        // A hex digit + \r\n + arbitrary invalid-UTF8 bytes (rendered as
+        // replacement chars by from_utf8_lossy) that intentionally place
+        // chunk_size past a multi-byte boundary.
+        let mut raw: Vec<u8> = b"c27\r\n".to_vec();
+        for _ in 0..4096 {
+            raw.push(0xC2); // invalid stray UTF-8 lead byte
+        }
+        let lossy = String::from_utf8_lossy(&raw);
+        // Must not panic; chunked decode should give up and return None.
+        assert!(ParsedRequest::decode_chunked_json(&lossy).is_none());
     }
 
     #[test]

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -283,16 +283,33 @@ impl SslSniff {
                 SslLibKind::GnuTls => attach_gnutls(&mut self.skel, &path, -1),
                 SslLibKind::Nss => attach_nss(&mut self.skel, &path, -1),
                 SslLibKind::Boring => {
-                    // BoringSSL doesn't export named symbols; detect by byte pattern.
-                    match find_boringssl_offsets(&path) {
-                        Some(off) => {
-                            attach_boringssl_by_offset(&mut self.skel, &path, &off, false, -1)
-                        }
-                        None => {
-                            log::warn!(
-                                "[attach_process] pid={pid}: BoringSSL byte-pattern detection failed for {path}, skipping"
+                    // BoringSSL detection in priority order:
+                    //   1. Symbol-based attach via .dynsym SSL_read/SSL_write/SSL_do_handshake.
+                    //      Works for BoringSSL builds that export these symbols
+                    //      (e.g. Hermes Node v22+, some self-built Node distributions).
+                    //   2. Byte-pattern offset scan for stripped builds whose SSL_*
+                    //      symbols are hidden (Claude Code's Node, Chrome, etc.).
+                    match attach_boringssl_by_symbol(&mut self.skel, &path, -1) {
+                        Ok(ls) => Ok(ls),
+                        Err(sym_err) => {
+                            log::debug!(
+                                "[attach_process] pid={pid}: BoringSSL symbol attach failed for {path} ({sym_err:#}), falling back to byte-pattern"
                             );
-                            continue;
+                            match find_boringssl_offsets(&path) {
+                                Some(off) => attach_boringssl_by_offset(
+                                    &mut self.skel,
+                                    &path,
+                                    &off,
+                                    false,
+                                    -1,
+                                ),
+                                None => {
+                                    log::warn!(
+                                        "[attach_process] pid={pid}: BoringSSL detection failed for {path} (no SSL_* in .dynsym and no byte-pattern match), skipping"
+                                    );
+                                    continue;
+                                }
+                            }
                         }
                     }
                 }
@@ -815,6 +832,46 @@ fn attach_nss(skel: &mut SslsniffSkel<'_>, lib: &str, pid: i32) -> Result<Vec<Li
         ur!(skel.progs_mut().probe_SSL_read_exit(), pid, lib, "PR_Read")?,
         up!(skel.progs_mut().probe_SSL_rw_enter(), pid, lib, "PR_Recv")?,
         ur!(skel.progs_mut().probe_SSL_read_exit(), pid, lib, "PR_Recv")?,
+    ])
+}
+
+/// Attach SSL probes to a BoringSSL build that exports its core symbols.
+///
+/// Some BoringSSL-embedding binaries (e.g. Hermes Node v22+) keep
+/// `SSL_read` / `SSL_write` / `SSL_do_handshake` visible in `.dynsym`, so we
+/// can attach by symbol name just like for OpenSSL. We deliberately do **not**
+/// try `SSL_write_ex` / `SSL_read_ex` here — BoringSSL drops these variants,
+/// so probing them would always fail.
+///
+/// Returns `Err` if any symbol is missing or attach fails; the caller is
+/// expected to fall back to byte-pattern offset detection.
+fn attach_boringssl_by_symbol(
+    skel: &mut SslsniffSkel<'_>,
+    lib: &str,
+    pid: i32,
+) -> Result<Vec<Link>> {
+    Ok(vec![
+        up!(skel.progs_mut().probe_SSL_rw_enter(), pid, lib, "SSL_write")?,
+        ur!(
+            skel.progs_mut().probe_SSL_write_exit(),
+            pid,
+            lib,
+            "SSL_write"
+        )?,
+        up!(skel.progs_mut().probe_SSL_rw_enter(), pid, lib, "SSL_read")?,
+        ur!(skel.progs_mut().probe_SSL_read_exit(), pid, lib, "SSL_read")?,
+        up!(
+            skel.progs_mut().probe_SSL_do_handshake_enter(),
+            pid,
+            lib,
+            "SSL_do_handshake"
+        )?,
+        ur!(
+            skel.progs_mut().probe_SSL_do_handshake_exit(),
+            pid,
+            lib,
+            "SSL_do_handshake"
+        )?,
     ])
 }
 

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -509,6 +509,26 @@ impl AgentSight {
                                     );
                                 }
                             }
+                            // ── FFI fan-out ──────────────────────────────────────
+                            // The deferred path (pending_response_id.is_some())
+                            // delivers LLMCall events to embedded consumers via
+                            // export_genai_events(), which in FFI mode pushes to
+                            // self.ffi_sender. This branch bypasses
+                            // export_genai_events() because the SQLite two-phase
+                            // write is hand-rolled above — but that bypass would
+                            // also skip the FFI fan-out, silently dropping every
+                            // LLMCall whose session_id is resolvable at build time
+                            // (i.e. whenever ResponseSessionMapper already has the
+                            // response_id, which is the common case after the very
+                            // first call). Push explicitly so embedded consumers
+                            // (LoongCollector / iLogtail) always receive the call.
+                            if let Some(ref sender) = self.ffi_sender {
+                                for event in &output.events {
+                                    if let GenAISemanticEvent::LLMCall(call) = event {
+                                        sender.send(FfiEvent::Llm(call.clone()));
+                                    }
+                                }
+                            }
                         } else {
                             self.export_genai_events(&output.events);
                         }


### PR DESCRIPTION
## Background
When LoongCollector embeds AgentSight via FFI to observe OpenClaw (Hermes Node + BoringSSL), three
issues combined to break the LLM pipeline: SSL probes failed to attach, only the very first event
reached downstream, and the worker thread panicked on binary request bodies. This PR fixes all
three so end-to-end LLM event delivery is restored.
## Scope of Changes
1. **BoringSSL probe attachment**: `src/agentsight/src/probes/sslsniff.rs` now tries symbol-based
   attach first (new `attach_boringssl_by_symbol`) and only falls back to the byte-pattern scanner
   when symbols are missing, so BoringSSL builds that export symbols (e.g. Hermes Node) no longer
   get silently skipped.
2. **FFI delivery on the immediate-export path**: `src/agentsight/src/unified.rs` now also pushes
   each `LLMCall` through the FFI sender in the SQLite-direct branch, fixing the regression where
   events were persisted but never forwarded once `ResponseSessionMapper` was warmed, so consumers
   received only the first event.
3. **HTTP request-body parser hardening**: `src/agentsight/src/parser/http/request.rs`'s
   `decode_chunked_json` switches every slice to `str::get(..)?` with `checked_add` and adds a
   regression test, preventing panics on OTLP/Protobuf bodies whose `from_utf8_lossy` form has
   `U+FFFD` chars sitting on the computed slice boundary.
## Known Issues / Caveats
- The byte pattern in `find_boringssl_offsets` is still hardcoded for the Node binary shipped with
  Claude Code; BoringSSL binaries that neither export SSL symbols nor match this pattern (different
  Node major versions, different LTO/PGO settings, different upstream sync dates) will still fail
  to attach. A follow-up should extend the pattern set or adopt a more generic locator.
- `decode_chunked_json` still attempts chunked decoding on arbitrary bodies; a follow-up can gate
  it on the `Transfer-Encoding` request header to further cut down false positives and wasted work.